### PR TITLE
Auto-detect Life360 auth_token from Next.js assets

### DIFF
--- a/life360.py
+++ b/life360.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timezone
 from curl_cffi import requests
 import logging
+import re
+from urllib.parse import urljoin
 
 # Docs for life 360 apis: https://krconv.github.io/life360-api-docs/
 # Inspired from https://github.com/harperreed/life360-python/blob/master/life360.py
-
 
 class Member:
     def __init__(self, conf: dict) -> None:
@@ -61,7 +62,7 @@ class Life360Connector:
         self.circle_ids: list[str] = conf["circle_ids"]
         self.impersonate: str = conf["impersonate"]
         self.access_token: str = ""
-
+ 
     def __get_headers(self, auth: str) -> dict:
         return {
             "Accept": "application/json",
@@ -82,10 +83,44 @@ class Life360Connector:
                 self.authenticate(True)
                 return self.__make_request(url, False)
             raise
+        
+    def findBasicAuth(self) -> bool:
+        BASE = "https://www.life360.com/en-gb/login"
+        SITE = "https://www.life360.com"
+
+        # Step 1: get login page
+        html = requests.get(BASE, impersonate=self.impersonate).text
+        # Step 2: find Next.js chunk JS files
+        chunks = re.findall(r'src="(/_next/static/chunks/[^"]+\.js)"', html)
+
+        token = None
+
+        for chunk in chunks:
+            url = urljoin(SITE, chunk)
+
+            js = requests.get(url, impersonate=self.impersonate).text
+
+            m = re.search(r'"basicToken":"([^"]+)"', js)
+            if m:
+                token = m.group(1)
+                logging.debug(f"Found token '{token}' in: {url}")
+                break
+
+        if token:
+            self.auth_token = token
+            return True
+        else:
+            return False
 
     def authenticate(self, force: bool = False) -> None:
         if self.access_token and not force:
             return
+
+        if self.auth_token == "detect":
+            logging.debug(f"Detecting Basic auth from Life360 assets.")
+            if not self.findBasicAuth():
+                logging.exception(f"Unable to detect basic auth.")
+                raise
 
         data = {"grant_type": "password", "username": self.username, "password": self.password}
 

--- a/template.config.toml
+++ b/template.config.toml
@@ -11,8 +11,9 @@ username = "user@email.com"  # Life360 login.
 password = "strong password" # Life360 password.
 # Optional. List of circles to process. If not specified, app will query the list of circles
 circle_ids = []
+
 # Shouldn't need to change the below entries; therefore don't need to set them to config.toml or env vars
-auth_token = "OWE5MDc4YTcxMjRkNjFkYjc1NGNjNzI4NjY2OTRkNWYwNDk2ODY2NDA6NjA2Nzk3MzkwODViYmMxZWY2ZjQyZjlmMDc3YjIwNTA"
+auth_token = "detect" # If this is set to detect the script will attempt to find the right auth_token
 base_url = "https://api-cloudfront.life360.com/v3/"
 user_agent = "com.life360.android.safetymapd"
 token_url = "oauth2/token.json"


### PR DESCRIPTION
This PR adds automatic detection of the Life360 `auth_token` (Basic Authorization token) by scraping the public login page and scanning the loaded Next.js chunk assets.

### Background

Life360 periodically rotates the static Basic authentication token used when requesting OAuth access tokens. Previously this token had to be manually updated in the configuration, which could cause the integration to break whenever Life360 changed it.

### Changes

* Added `findBasicAuth()` method to dynamically locate the `basicToken` value from Life360's frontend assets.
* The login page (`/en-gb/login`) is fetched and all referenced `/_next/static/chunks/*.js` files are scanned.
* The script searches these files for the `basicToken` value and extracts it automatically.
* When `auth_token = "detect"` is set in the config, the script will attempt to discover the correct token before authenticating.

### Config Updates

The configuration now supports automatic detection:

```toml
auth_token = "detect"
```

If detection fails, the script will raise an exception to prevent silent authentication failures.

### Benefits

* Removes the need to manually update the Life360 Basic auth token.
* Makes the integration resilient to frontend token rotations.
* Keeps compatibility with manual token configuration if desired.

### Notes

The detection works by parsing publicly available frontend assets and does not rely on undocumented API endpoints.
